### PR TITLE
mt6895-common: media: add "can-swap-width-height" for video codecs

### DIFF
--- a/configs/media/media_codecs_c2.xml
+++ b/configs/media/media_codecs_c2.xml
@@ -26,6 +26,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.MPEG4" />
             <Limit name="size" min="16x16" max="2048x1088" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -33,6 +34,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.H263" />
             <Limit name="size" min="128x96" max="1408x1152" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-1280x720" value="30" />
         </MediaCodec>
@@ -41,6 +43,7 @@
             <Limit name="size" min="64x64" max="4096x2176" />
             <Quirk name="wants-NAL-fragments" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x719" value="180" />
@@ -52,6 +55,7 @@
             <Quirk name="wants-NAL-fragments" />
             <Feature name="secure-playback" required="true" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="1" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -59,6 +63,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.HEVC" />
             <Limit name="size" min="16x16" max="4096x2176" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x719" value="180" />
@@ -69,6 +74,7 @@
             <Limit name="size" min="16x16" max="1920x1088" />
             <Feature name="secure-playback" required="true" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="1" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -76,6 +82,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.HEIF" />
             <Limit name="size" min="16x16" max="16383x16383" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-3840x2160" value="30" />
         </MediaCodec>
@@ -83,6 +90,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.VPX" />
             <Limit name="size" min="16x16" max="2048x1088" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -90,6 +98,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.VP9" />
             <Limit name="size" min="16x16" max="4096x2176" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x720" value="60" />
@@ -100,6 +109,7 @@
             <Quirk name="wants-NAL-fragments" />
             <Feature name="secure-playback" required="true" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="1" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -107,6 +117,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.AV1" />
             <Limit name="size" min="16x16" max="4096x2176" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x719" value="180" />
@@ -118,6 +129,7 @@
             <Quirk name="wants-NAL-fragments" />
             <Feature name="secure-playback" required="true" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="1" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -125,6 +137,7 @@
             <Alias name="OMX.MTK.VIDEO.DECODER.MPEG2" />
             <Limit name="size" min="16x16" max="2048x1088" />
             <Feature name="adaptive-playback"/>
+            <Feature name="can-swap-width-height" value="1" />
             <Limit name="concurrent-instances" max="15" />
             <Limit name="performance-point-1920x1088" value="30" />
         </MediaCodec>
@@ -139,6 +152,7 @@
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x719" value="180" />
             <Limit name="performance-point-1280x720" value="120" />
+            <Feature name="can-swap-width-height" value="1" />
         </MediaCodec>
         <MediaCodec name="c2.mtk.avc.encoder.secure" type="video/avc" >
             <Limit name="size" min="160x128" max="3840x2176" />
@@ -147,6 +161,7 @@
             <Limit name="concurrent-instances" max="10" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Feature name="special-codec" required="true" />
+            <Feature name="can-swap-width-height" value="1" />
         </MediaCodec>
         <MediaCodec name="c2.mtk.hevc.encoder" type="video/hevc" >
             <Alias name="OMX.MTK.VIDEO.ENCODER.HEVC" />
@@ -159,6 +174,7 @@
             <Limit name="performance-point-3840x2160" value="30" />
             <Limit name="performance-point-1280x719" value="180" />
             <Limit name="performance-point-1280x720" value="120" />
+            <Feature name="can-swap-width-height" value="1" />
         </MediaCodec>
         <MediaCodec name="c2.mtk.hevc.encoder.secure" type="video/hevc" >
             <Limit name="size" min="160x128" max="3840x2160" />
@@ -169,6 +185,7 @@
             <Feature name="bitrate-modes" value="VBR,CBR,CQ" />
             <Limit name="performance-point-3840x2160" value="30" />
             <Feature name="special-codec" required="true" />
+            <Feature name="can-swap-width-height" value="1" />
         </MediaCodec>
         <MediaCodec name="c2.mtk.heif.encoder" type="image/vnd.android.heic" >
             <Alias name="OMX.MTK.VIDEO.ENCODER.HEIF" />
@@ -179,6 +196,7 @@
             <Limit name="concurrent-instances" max="16" />
             <Feature name="bitrate-modes" value="VBR,CBR,CQ" />
             <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="can-swap-width-height" value="1" />
         </MediaCodec>
     </Encoders>
 </MediaCodecs>


### PR DESCRIPTION
[VSR-4.2-004.002] MUST support identical size ranges horizontally
as vertically (for example, support portrait videos of the same size
if they support a landscape video size.)

Bug: 322453106
Test: atest android.mediav2.cts.CodecInfoTest
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:aa514b3779b94a7dc40dab302c84ab8ae97becfa)
Merged-In: I6918bc926964c8dd398d686ee3e7713d4f023ff2
Change-Id: I6918bc926964c8dd398d686ee3e7713d4f023ff2

Change-Id: I24c3a9f5e1f58b8487d574cec91d764343c4690d