### PR TITLE
mt6895-common: Enable Wi-Fi Calling by default

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -102,6 +102,7 @@ persist.vendor.ims_support=1
 persist.vendor.mtk_ct_volte_support=3
 persist.vendor.mtk_dynamic_ims_switch=1
 persist.vendor.mtk_wfc_support=1
+persist.vendor.mtk.wfc.enable=1
 persist.vendor.mtk.volte.enable=1
 persist.vendor.vilte_support=1
 persist.vendor.viwifi_support=1


### PR DESCRIPTION
It was declared in stock, and works on AOSP too, if we don't enable it, people might not enable it themselves and face low call quality