### PR TITLE
mt6895-common: allow Arcsoft night camera props

### DIFF
--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -4,6 +4,8 @@ persist.vendor.accelerate.charge            u:object_r:vendor_batterysecret_prop
 # Camera
 ro.boot.camera.                             u:object_r:vendor_mtk_camera_prop:s0
 persist.vendor.camera.                      u:object_r:vendor_mtk_camera_prop:s0
+# Arcsoft super night reads this vendor namespace directly from the app process.
+vendor.arcsoft.sn_                          u:object_r:vendor_mtk_camera_prop:s0
 vendor.debug.appcontrol.name                u:object_r:vendor_mtk_camera_prop:s0
 
 # Fingerprint


### PR DESCRIPTION
ArcSoft asks for this in the camera app, it doesn't cost anything to allow it access. The reason for this is still unknown.