### PR TITLE
mt6895-common: Update vibrator inherit-product call

### DIFF
--- a/mt6895.mk
+++ b/mt6895.mk
@@ -336,11 +336,7 @@ PRODUCT_PACKAGES += \
 # Vibrator
 $(call soong_config_set, vibrator, vibratortargets, vibratoraidlV2target)
 
-PRODUCT_PACKAGES += \
-    vendor.qti.hardware.vibrator.service
-
-PRODUCT_COPY_FILES += \
-    vendor/qcom/opensource/vibrator/excluded-input-devices.xml:$(TARGET_COPY_OUT_VENDOR)/etc/excluded-input-devices.xml
+$(call inherit-product, vendor/qcom/opensource/vibrator/vibrator-vendor-product.mk)
 
 # Wi-Fi
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Saw this in newer trees by bengris32. The core behavior is the same, although there is one thing that we don't call

This one :-
```
      vendor/qcom/opensource/vibrator/aidl/HapticsPolicy.xml:vendor/etc/HapticsPolicy.xml
```

I think we should use this makefile so we don't have to worry about upstream changes. Also, I did notice some extra haptics in PixelOS Launcher while moving apps in Homescreen. HapticsPolicy.xml could be adding that, although I am not sure