### PR TITLE
mt6895-common: overlay: Import NetworkStack overlayed resources by MediaTek

### DIFF
--- a/mt6895.mk
+++ b/mt6895.mk
@@ -180,6 +180,7 @@ PRODUCT_COPY_FILES += \
 # Overlays
 PRODUCT_PACKAGES += \
     FrameworksResOverlayMT6895 \
+    NetworkStackOverlayMT6895 \
     PowerOffAlarmOverlayMT6895 \
     TelephonyOverlayMT6895 \
     Launcher3QuickStepOverlayMT6895 \

--- a/overlay/NetworkStackOverlayMT6895/Android.bp
+++ b/overlay/NetworkStackOverlayMT6895/Android.bp
@@ -1,0 +1,9 @@
+//
+// SPDX-FileCopyrightText: The LineageOS Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+runtime_resource_overlay {
+    name: "NetworkStackOverlayMT6895",
+    product_specific: true,
+}

--- a/overlay/NetworkStackOverlayMT6895/AndroidManifest.xml
+++ b/overlay/NetworkStackOverlayMT6895/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: The LineageOS Project
+SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.networkstack.overlay.mt6895">
+
+    <overlay
+        android:isStatic="true"
+        android:priority="100"
+        android:targetPackage="com.android.networkstack" />
+</manifest>

--- a/overlay/NetworkStackOverlayMT6895/res/values/config.xml
+++ b/overlay/NetworkStackOverlayMT6895/res/values/config.xml
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: The LineageOS Project
+SPDX-License-Identifier: Apache-2.0
+-->
+<resources>
+    <!-- Literal commas are not allowed in the url configuration because they
+    are used as a separator internally. -->
+    <string-array name="config_captive_portal_https_urls" translatable="false">
+        <item>https://connectivitycheck.gstatic.com/generate_204</item>
+    </string-array>
+
+    <!-- Set to true if NetworkMonitor needs to load the resource by neighbor mcc when device
+    doesn't have a SIM card inserted. -->
+    <bool name="config_no_sim_card_uses_neighbor_mcc">true</bool>
+
+    <!-- Configuration for including DHCP client hostname option -->
+    <bool name="config_dhcp_client_hostname">true</bool>
+</resources>


### PR DESCRIPTION

* MediaTek always overlays those resources, it doesn't hurt to add them into AOSP.

If no SIM is there, the device tries to connect to the nearest tower to fetch info instead of using the connected Wi-Fi. Rest Mashopy is intelligent enough he added for a reason.